### PR TITLE
Additional rules regarding self-signed certs

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "rules": {
         "no-unsafe-regex": 0,
         "no-timing-attacks": 0,
-		"no-self-signed-cert-node": 0,
+	"no-self-signed-cert-node": 0,
         "no-self-signed-cert-mongoose": 0
     }
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
     "rules": {
         "no-unsafe-regex": 0,
-        "no-timing-attacks": 1
+        "no-timing-attacks": 0,
+		"no-self-signed-cert-node": 0,
+        "no-self-signed-cert-mongoose": 0
     }
 }

--- a/no-self-signed-cert-mongoose.js
+++ b/no-self-signed-cert-mongoose.js
@@ -1,0 +1,43 @@
+/**
+ * Looks for mongoose connections which accept self-signed certificates
+ * @author Geller Bedoya
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+    var isMongooseInstalled = false;
+
+    return {
+        "Literal": function(node) {
+
+            var token = context.getTokens(node)[0],
+                nodeType = token.type,
+                nodeValue = token.value;
+
+            if (nodeValue === 'mongoose' ||
+                nodeValue === "'mongoose'" &&
+                node.parent.type === 'CallExpression' &&
+                node.parent.callee.name === 'require' &&
+                node.parent.parent.type === 'AssignmentExpression' ||
+                node.parent.parent.type === 'VariableDeclarator'
+            ) {
+                isMongooseInstalled = true;
+            }
+            if (isMongooseInstalled) {
+                if (nodeValue === 'false' && node.parent.key.name === 'sslValidate') {
+                    var nodeGrandparent = node.parent.parent;
+                    if (nodeGrandparent.type === 'ObjectExpression' &&
+                        nodeGrandparent.parent.key.name === 'server'
+                    ) {
+                        context.report(node, "Moogoose Accepts Self-Signed Certs");
+                    }
+                }
+            }
+        }
+    };
+};

--- a/no-self-signed-cert-node.js
+++ b/no-self-signed-cert-node.js
@@ -1,0 +1,43 @@
+/**
+ * Looks for node apps with self-signed certificates
+ * @author Geller Bedoya
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+        "Literal": function(node) {
+
+            var token = context.getTokens(node)[0],
+                nodeType = token.type,
+                nodeValue = token.value;
+
+            if (nodeValue === 'NODE_TLS_REJECT_UNAUTHORIZED') {
+                if (node.parent.type === 'MemberExpression' &&
+                    node.parent.parent.type === 'AssignmentExpression' &&
+                    node.parent.parent.right.value === "'0'" ||
+                    node.parent.parent.right.value === '"0"'
+                ) {
+                    context.report(node, "Node Accepts Self-Signed Certs");
+                }
+            }
+
+            if (nodeType === "String") {
+                if (nodeValue === "'0'" ||
+                    nodeValue === '"0"' &&
+                    node.parent.type === 'AssignmentExpression' &&
+                    node.parent.left.type === 'MemberExpression' &&
+                    node.parent.left.property.name === 'NODE_TLS_REJECT_UNAUTHORIZED'
+                ) {
+                    context.report(node, "Node Accepts Self-Signed Certs");
+                }
+            }
+        }
+    };
+};

--- a/tests/mongoose-self-signed-cert.js
+++ b/tests/mongoose-self-signed-cert.js
@@ -1,0 +1,14 @@
+var mongoose = require('mongoose');
+
+var dboptions = {
+  	db: { native_parser: true },
+    server: {
+        sslValidate: false
+    }
+}
+
+mongoose.connect( dbconnect, { server: { sslValidate: true }});
+mongoose.connect( dbconnect, { server: { sslValidate: false }});
+
+// false-positive
+foo.bar( dbconnect, { server: { sslValidate: false }});

--- a/tests/node-self-signed-cert.js
+++ b/tests/node-self-signed-cert.js
@@ -1,0 +1,7 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = "0";
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';


### PR DESCRIPTION
@evilpacket I've created two additional rules to detect self-signed certs in Node apps & Mongoose. Your welcome to accept the pull-request or comments are welcomed as well.

Also, `no-self-signed-cert-mongoose.js` does result in a false-positive for a particular use case (see tests). Thoughts on how to resolve this particular problem?
